### PR TITLE
support $fx.emit data emission

### DIFF
--- a/src/components/FxParams/Controller/Boolean.tsx
+++ b/src/components/FxParams/Controller/Boolean.tsx
@@ -2,12 +2,13 @@ import { FxParamControllerProps, HTMLInputController } from "./Controller"
 import classes from "./Controller.module.scss"
 
 export function BooleanController(props: FxParamControllerProps<"boolean">) {
+  const { inputProps, ...rest } = props
   return (
     <HTMLInputController
       type="checkbox"
       layout="box"
-      inputProps={{ checked: props.value }}
-      {...props}
+      inputProps={{ checked: props.value, ...inputProps }}
+      {...rest}
     />
   )
 }

--- a/src/components/FxParams/Controller/Boolean.tsx
+++ b/src/components/FxParams/Controller/Boolean.tsx
@@ -2,12 +2,12 @@ import { FxParamControllerProps, HTMLInputController } from "./Controller"
 import classes from "./Controller.module.scss"
 
 export function BooleanController(props: FxParamControllerProps<"boolean">) {
-  const { inputProps, ...rest } = props
+  const { ...rest } = props
   return (
     <HTMLInputController
       type="checkbox"
       layout="box"
-      inputProps={{ checked: props.value, ...inputProps }}
+      inputProps={{ checked: props.value }}
       {...rest}
     />
   )

--- a/src/components/FxParams/Controller/Color.tsx
+++ b/src/components/FxParams/Controller/Color.tsx
@@ -21,7 +21,7 @@ import { BaseButton } from "../BaseInput"
 
 export function ColorController(props: FxParamControllerProps<"color">) {
   const ref = useRef<HTMLDivElement>(null)
-  const { label, id, onChange, value, layout = "box" } = props
+  const { label, id, onChange, value, layout = "box", isCodeDriven } = props
   const [showPicker, setShowPicker] = useState(false)
   const handleToggleShowPicker = () => {
     setShowPicker((show) => !show)
@@ -52,10 +52,12 @@ export function ColorController(props: FxParamControllerProps<"color">) {
       layout={layout}
       className={classes.pickerWrapper}
       inputContainerProps={{ ref }}
+      isCodeDriven={isCodeDriven}
     >
       <BaseButton
         className={cx(classes.squaredButton, { [classes.active]: showPicker })}
         onClick={handleToggleShowPicker}
+        disabled={isCodeDriven}
       >
         <div
           className={cx(classes.square, classes.leftTop)}
@@ -75,6 +77,7 @@ export function ColorController(props: FxParamControllerProps<"color">) {
         autoComplete="off"
         maxLength={9}
         minLength={2}
+        disabled={isCodeDriven}
       />
       {showPicker && (
         <div className={classes.pickerAbsoluteWrapper}>

--- a/src/components/FxParams/Controller/Controller.tsx
+++ b/src/components/FxParams/Controller/Controller.tsx
@@ -107,6 +107,7 @@ export function HTMLInputController(props: HTMLInputControllerProps) {
         id={id}
         onChange={onChange}
         value={value}
+        disabled={isCodeDriven}
         {...inputProps}
       />
     </Controller>
@@ -131,9 +132,15 @@ export function HTMLInputControllerWithTextInput(
     inputProps = {},
     layout = "default",
     textInputProps,
+    isCodeDriven,
   } = props
   return (
-    <Controller id={id} label={label} layout={layout}>
+    <Controller
+      id={id}
+      label={label}
+      layout={layout}
+      isCodeDriven={isCodeDriven}
+    >
       <BaseParamsInput
         className={className}
         type={type}
@@ -141,6 +148,7 @@ export function HTMLInputControllerWithTextInput(
         onChange={onChange}
         value={value}
         autoComplete="off"
+        disabled={isCodeDriven}
         {...inputProps}
       />
       <BaseParamsInput
@@ -149,6 +157,7 @@ export function HTMLInputControllerWithTextInput(
         onChange={onChange}
         value={value}
         autoComplete="off"
+        disabled={isCodeDriven}
         {...textInputProps}
       />
     </Controller>

--- a/src/components/FxParams/Controller/Controller.tsx
+++ b/src/components/FxParams/Controller/Controller.tsx
@@ -32,6 +32,7 @@ export interface ControllerProps {
   inputContainerProps?: {
     ref: RefObject<HTMLDivElement>
   }
+  isCodeDriven?: boolean
 }
 
 export function Controller(props: ControllerProps) {
@@ -41,9 +42,17 @@ export function Controller(props: ControllerProps) {
     layout = "default",
     className,
     inputContainerProps,
+    isCodeDriven,
   } = props
   return (
-    <div className={cx(classes.controller, classes[layout], className)}>
+    <div
+      className={cx(classes.controller, classes[layout], className)}
+      title={
+        isCodeDriven
+          ? "This parameter is solely code-driven. Controller is just shown for debugging purposes."
+          : ""
+      }
+    >
       {id && <label htmlFor={id}>{label || id}</label>}
       <div className={classes.inputContainer} {...inputContainerProps}>
         {props.children}
@@ -61,6 +70,7 @@ export interface HTMLInputControllerProps {
   className?: string
   label?: string
   layout?: "default" | "invert" | "box"
+  isCodeDriven?: boolean
 }
 
 export type FxParamControllerProps<Type extends FxParamType> = Omit<
@@ -80,11 +90,17 @@ export function HTMLInputController(props: HTMLInputControllerProps) {
     value,
     type,
     className,
-    inputProps = {},
+    inputProps,
     layout = "default",
+    isCodeDriven,
   } = props
   return (
-    <Controller id={id} label={label} layout={layout}>
+    <Controller
+      id={id}
+      label={label}
+      layout={layout}
+      isCodeDriven={isCodeDriven}
+    >
       <BaseParamsInput
         className={className}
         type={type}

--- a/src/components/FxParams/Controller/Number.tsx
+++ b/src/components/FxParams/Controller/Number.tsx
@@ -6,7 +6,7 @@ import classes from "./Controller.module.scss"
 import { useMemo } from "react"
 
 export function NumberController(props: FxParamControllerProps<"number">) {
-  const { options, value } = props
+  const { options, value, inputProps } = props
   const min = useMemo(() => {
     if (typeof options?.min === "undefined") return Number.MIN_SAFE_INTEGER
     return options.min

--- a/src/components/FxParams/Controller/Param.tsx
+++ b/src/components/FxParams/Controller/Param.tsx
@@ -91,6 +91,8 @@ export function ParameterController(props: ParameterControllerProps) {
       />
     )
 
+  const isCodeDriven = parameter.update === "code-driven"
+
   return (
     <Controller
       id={parameter.id}
@@ -99,6 +101,10 @@ export function ParameterController(props: ParameterControllerProps) {
       onChange={handleChangeParam}
       // TODO: This should be properly casted
       options={parameter.options as any}
+      isCodeDriven={isCodeDriven}
+      inputProps={{
+        disabled: isCodeDriven,
+      }}
     />
   )
 }

--- a/src/components/FxParams/Controller/Param.tsx
+++ b/src/components/FxParams/Controller/Param.tsx
@@ -102,9 +102,6 @@ export function ParameterController(props: ParameterControllerProps) {
       // TODO: This should be properly casted
       options={parameter.options as any}
       isCodeDriven={isCodeDriven}
-      inputProps={{
-        disabled: isCodeDriven,
-      }}
     />
   )
 }

--- a/src/components/FxParams/Controller/Select.tsx
+++ b/src/components/FxParams/Controller/Select.tsx
@@ -7,10 +7,17 @@ export function SelectController({
   value,
   onChange,
   options,
+  isCodeDriven,
 }: FxParamControllerProps<"select">) {
   return (
-    <Controller id={id} label={label}>
-      <BaseSelect name={id} id={id} onChange={onChange} value={value}>
+    <Controller id={id} label={label} isCodeDriven={isCodeDriven}>
+      <BaseSelect
+        name={id}
+        id={id}
+        onChange={onChange}
+        value={value}
+        disabled={isCodeDriven}
+      >
         {options?.options.map((o) => (
           <option key={o} value={o}>
             {o}

--- a/src/components/FxParams/types.ts
+++ b/src/components/FxParams/types.ts
@@ -44,7 +44,7 @@ export interface FxParamTypeMap {
   select: string
 }
 
-export type FxParamUpdateMode = "page-reload" | "sync"
+export type FxParamUpdateMode = "page-reload" | "sync" | "code-driven"
 
 export interface FxParamDefinition<Type extends FxParamType> {
   id: string

--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -7,7 +7,6 @@ import { PanelRoot } from "./Panel/PanelRoot"
 
 export function App() {
   const ctx = useContext(MainContext)
-
   return (
     <div className={style.root}>
       <Layout panel={<PanelRoot />} frame={<Frame url={ctx.url} />} />

--- a/src/containers/Panel/PanelContext.module.scss
+++ b/src/containers/Panel/PanelContext.module.scss
@@ -1,0 +1,3 @@
+.select {
+  width: 100%;
+}

--- a/src/containers/Panel/PanelContext.tsx
+++ b/src/containers/Panel/PanelContext.tsx
@@ -1,0 +1,47 @@
+import styles from "./PanelContext.module.scss"
+import { useContext } from "react"
+import { MainContext } from "context/MainContext"
+import { faRotate } from "@fortawesome/free-solid-svg-icons"
+import { PanelGroup } from "components/Panel/PanelGroup"
+import {
+  BaseInput,
+  BaseSelect,
+  IconButton,
+} from "components/FxParams/BaseInput"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { RuntimeContext, TExecutionContext } from "context/RuntimeContext"
+
+const contexts = ["minting", "standalone", "capture"]
+
+export function PanelContext() {
+  const ctx = useContext(MainContext)
+  const runtime = useContext(RuntimeContext)
+
+  const handleChange = (context: TExecutionContext) => {
+    runtime.state.update({ context })
+  }
+
+  return (
+    <PanelGroup
+      title="Execution context"
+      description="Simulate different contexts in which the code will be executed."
+    >
+      <div className={styles.hashControls}>
+        <BaseSelect
+          name="context"
+          className={styles.select}
+          value={runtime.state.context}
+          onChange={(evt) =>
+            handleChange(evt.target.value as TExecutionContext)
+          }
+        >
+          {contexts.map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </BaseSelect>
+      </div>
+    </PanelGroup>
+  )
+}

--- a/src/containers/Panel/PanelControls.tsx
+++ b/src/containers/Panel/PanelControls.tsx
@@ -15,6 +15,7 @@ const updateIframe: TUpdateIframe = (ctx, runtime) => {
     minter: runtime.state.minter,
     data: runtime.state.params,
     params: runtime.definition.params,
+    iteration: runtime.state.iteration,
   })
   const target = url.toString()
   if (ctx.iframe) {

--- a/src/containers/Panel/PanelControls.tsx
+++ b/src/containers/Panel/PanelControls.tsx
@@ -16,6 +16,7 @@ const updateIframe: TUpdateIframe = (ctx, runtime) => {
     data: runtime.state.params,
     params: runtime.definition.params,
     iteration: runtime.state.iteration,
+    context: runtime.state.context,
   })
   const target = url.toString()
   if (ctx.iframe) {

--- a/src/containers/Panel/PanelIteration.module.scss
+++ b/src/containers/Panel/PanelIteration.module.scss
@@ -1,0 +1,9 @@
+.iterationControls {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+}
+
+.numberInput {
+  text-align: center;
+}

--- a/src/containers/Panel/PanelIteration.tsx
+++ b/src/containers/Panel/PanelIteration.tsx
@@ -1,0 +1,51 @@
+import styles from "./PanelIteration.module.scss"
+import { useContext } from "react"
+import { faPlus, faMinus } from "@fortawesome/free-solid-svg-icons"
+import { PanelGroup } from "components/Panel/PanelGroup"
+import { BaseInput, IconButton } from "components/FxParams/BaseInput"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { RuntimeContext } from "context/RuntimeContext"
+
+export function PanelIteration() {
+  const runtime = useContext(RuntimeContext)
+
+  const handleDecrease = () => {
+    if (runtime.state.iteration === 1) return
+    runtime.state.update({
+      iteration: runtime.state.iteration - 1,
+    })
+  }
+
+  const handleIncrease = () => {
+    runtime.state.update({
+      iteration: runtime.state.iteration + 1,
+    })
+  }
+
+  const handleChangeIterationNumber = (e: any) => {
+    const num = +e.target.value
+    if (isNaN(num)) return
+    runtime.state.update({
+      iteration: num,
+    })
+  }
+
+  return (
+    <PanelGroup title="Iteration" description="The number of the iteration">
+      <div className={styles.iterationControls}>
+        <IconButton onClick={handleDecrease} color="secondary">
+          <FontAwesomeIcon icon={faMinus} size="1x" />
+        </IconButton>
+        <BaseInput
+          className={styles.numberInput}
+          onChange={handleChangeIterationNumber}
+          type="text"
+          value={runtime.state.iteration}
+        />
+        <IconButton onClick={handleIncrease} color="secondary">
+          <FontAwesomeIcon icon={faPlus} size="1x" />
+        </IconButton>
+      </div>
+    </PanelGroup>
+  )
+}

--- a/src/containers/Panel/PanelParams.module.scss
+++ b/src/containers/Panel/PanelParams.module.scss
@@ -35,3 +35,8 @@
     color: var(--fxl-color-light) !important;
   }
 }
+
+.codeDrivenNote {
+  padding: var(--fxl-spacing-xs);
+  border: 1px solid var(--fxl-color-light2);
+}

--- a/src/containers/Panel/PanelParams.tsx
+++ b/src/containers/Panel/PanelParams.tsx
@@ -66,7 +66,7 @@ export function PanelParams() {
     [runtime.state.params]
   )
 
-  useMessageListener("fxhash_emitParams", updateData)
+  useMessageListener("fxhash_emit:params:update", updateData)
 
   const handleRandomizeParams = () => {
     const randomValues = getRandomParamValues(

--- a/src/containers/Panel/PanelParams.tsx
+++ b/src/containers/Panel/PanelParams.tsx
@@ -108,6 +108,11 @@ export function PanelParams() {
     [lockedParamIds?.length, runtime.definition.params?.length]
   )
 
+  const allParamsCodeDriven = useMemo(
+    () => runtime.definition.params?.every((p) => p.update === "code-driven"),
+    [runtime.definition.params]
+  )
+
   return (
     <PanelGroup
       title="Params"
@@ -122,7 +127,7 @@ export function PanelParams() {
           color="secondary"
           className={classes.randomButton}
           onClick={handleRandomizeParams}
-          disabled={allLocked}
+          disabled={allLocked || allParamsCodeDriven}
         >
           Randomize Params
         </BaseButton>
@@ -160,6 +165,12 @@ export function PanelParams() {
           data={runtime.state.params}
         />
       </div>
+      {allParamsCodeDriven && (
+        <p className={classes.codeDrivenNote}>
+          All params of this artwork are defined as "code-driven". This will
+          enable a dedicated minting experience for collectors on fxhash.xyz
+        </p>
+      )}
     </PanelGroup>
   )
 }

--- a/src/containers/Panel/PanelRoot.tsx
+++ b/src/containers/Panel/PanelRoot.tsx
@@ -6,6 +6,7 @@ import { PanelFeatures } from "./PanelFeatures"
 import { PanelControls } from "./PanelControls"
 import { PanelHash } from "./PanelHash"
 import { PanelAddress } from "./PanelAddress"
+import { PanelIteration } from "./PanelIteration"
 
 export function PanelRoot() {
   return (
@@ -17,6 +18,7 @@ export function PanelRoot() {
           <PanelHash />
           <PanelAddress />
           <PanelParams />
+          <PanelIteration />
           <PanelFeatures />
         </div>
       </div>

--- a/src/containers/Panel/PanelRoot.tsx
+++ b/src/containers/Panel/PanelRoot.tsx
@@ -7,6 +7,7 @@ import { PanelControls } from "./PanelControls"
 import { PanelHash } from "./PanelHash"
 import { PanelAddress } from "./PanelAddress"
 import { PanelIteration } from "./PanelIteration"
+import { PanelContext } from "./PanelContext"
 
 export function PanelRoot() {
   return (
@@ -17,6 +18,7 @@ export function PanelRoot() {
         <div className={cs(style.body)}>
           <PanelHash />
           <PanelAddress />
+          <PanelContext />
           <PanelParams />
           <PanelIteration />
           <PanelFeatures />

--- a/src/context/MainContext.tsx
+++ b/src/context/MainContext.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren, useState } from "react"
 import { createContext } from "react"
-import { decodeUrl } from "utils/url"
+import { appendUrlParameters, decodeUrl } from "utils/url"
+import { TExecutionContext } from "./RuntimeContext"
 
 /**
  * The Main Context will wait for the project URL to be available to render
@@ -38,11 +39,17 @@ export const MainContext = createContext(defaultMainContext)
 
 type Props = PropsWithChildren<any>
 export function MainProvider({ children }: Props) {
-  const [baseUrl, _] = useState(
-    decodeUrl(new URLSearchParams(window.location.search).get("target") || "")
+  const baseUrl = decodeUrl(
+    new URLSearchParams(window.location.search).get("target") || ""
   )
+  const initialContext = new URLSearchParams(window.location.search).get(
+    "fxcontext"
+  ) as TExecutionContext
+
   // initialize the URL from the query parameter target
-  const [url, setUrl] = useState(baseUrl)
+  const [url, setUrl] = useState(
+    appendUrlParameters(baseUrl, { fxcontext: initialContext })
+  )
 
   const [features, setFeatures] = useState<any>(null)
 

--- a/src/context/RuntimeContext.tsx
+++ b/src/context/RuntimeContext.tsx
@@ -21,6 +21,7 @@ export interface RuntimeState {
   hash: string
   minter: string
   params: FxParamsData
+  iteration: number
 }
 
 export interface RuntimeDefinition {
@@ -80,6 +81,7 @@ const defaultRuntimeContext: IRuntimeContext = {
     minter: "",
     params: {},
     update: () => {},
+    iteration: 1,
   },
   definition: {
     params: null,
@@ -103,6 +105,7 @@ export function RuntimeProvider({ children }: Props) {
     hash: "",
     minter: "",
     params: {},
+    iteration: 1,
   })
   const [definition, setDefinition] = useState<RuntimeDefinition>({
     params: null,

--- a/src/context/RuntimeContext.tsx
+++ b/src/context/RuntimeContext.tsx
@@ -113,17 +113,17 @@ export function RuntimeProvider({ children }: Props) {
   })
 
   const update: TUpdateStateFn<RuntimeState> = (data) => {
-    setState({
-      ...state,
+    setState((lastState) => ({
+      ...lastState,
       ...data,
-    })
+    }))
   }
 
   const updateDefinition: TUpdateStateFn<RuntimeDefinition> = (data) => {
-    setDefinition({
-      ...definition,
+    setDefinition((lastDefinition) => ({
+      ...lastDefinition,
       ...data,
-    })
+    }))
   }
 
   // enhance each param definition with the version (useful for serialization)

--- a/src/context/RuntimeContext.tsx
+++ b/src/context/RuntimeContext.tsx
@@ -110,7 +110,10 @@ export function RuntimeProvider({ children }: Props) {
     minter: "",
     params: {},
     iteration: 1,
-    context: "standalone",
+    context:
+      (new URLSearchParams(window.location.search).get(
+        "fxcontext"
+      ) as TExecutionContext) || "standalone",
   })
   const [definition, setDefinition] = useState<RuntimeDefinition>({
     params: null,

--- a/src/context/RuntimeContext.tsx
+++ b/src/context/RuntimeContext.tsx
@@ -17,11 +17,14 @@ import { TUpdateStateFn, TUpdateableState } from "types/utils"
  * See comments on IRuntimeContext for more details.
  */
 
+export type TExecutionContext = "minting" | "standalone" | "capture"
+
 export interface RuntimeState {
   hash: string
   minter: string
   params: FxParamsData
   iteration: number
+  context: TExecutionContext
 }
 
 export interface RuntimeDefinition {
@@ -82,6 +85,7 @@ const defaultRuntimeContext: IRuntimeContext = {
     params: {},
     update: () => {},
     iteration: 1,
+    context: "standalone",
   },
   definition: {
     params: null,
@@ -106,6 +110,7 @@ export function RuntimeProvider({ children }: Props) {
     minter: "",
     params: {},
     iteration: 1,
+    context: "standalone",
   })
   const [definition, setDefinition] = useState<RuntimeDefinition>({
     params: null,

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -16,11 +16,14 @@ export function createIframeUrl(
     minter?: string | null
     data?: Record<string, FxParamType> | null
     params?: FxParamDefinition<FxParamType>[] | null
+    iteration?: number
   }
 ) {
   const url = new URL(baseUrl)
   if (options?.hash) url.searchParams.append("fxhash", options.hash)
   if (options?.minter) url.searchParams.append("fxminter", options.minter)
+  if (options?.iteration)
+    url.searchParams.append("fxiteration", `${options.iteration}`)
   if (options?.data) {
     const bytes = serializeParams(options?.data, options?.params || [])
     url.searchParams.append("fxparams", `0x${bytes}`)

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -33,3 +33,21 @@ export function createIframeUrl(
   url.searchParams.append("fxcontext", options?.context || "standalone")
   return url
 }
+export function appendUrlParameters(
+  url: string,
+  parameters: Record<string, string | null>
+): string {
+  const params = Object.entries(parameters)
+    .filter(([key, value]) => value !== null)
+    .map(
+      ([key, value]) =>
+        `${encodeURIComponent(key)}=${encodeURIComponent(value as string)}`
+    )
+    .join("&")
+
+  if (params) {
+    return `${url}${url.includes("?") ? "&" : "?"}${params}`
+  }
+
+  return url
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,5 +1,6 @@
 import { FxParamDefinition, FxParamType } from "components/FxParams/types"
 import { serializeParams } from "components/FxParams/utils"
+import { TExecutionContext } from "context/RuntimeContext"
 
 export function encodeUrl(url: string) {
   return encodeURIComponent(url)
@@ -17,6 +18,7 @@ export function createIframeUrl(
     data?: Record<string, FxParamType> | null
     params?: FxParamDefinition<FxParamType>[] | null
     iteration?: number
+    context?: TExecutionContext
   }
 ) {
   const url = new URL(baseUrl)
@@ -28,5 +30,6 @@ export function createIframeUrl(
     const bytes = serializeParams(options?.data, options?.params || [])
     url.searchParams.append("fxparams", `0x${bytes}`)
   }
+  url.searchParams.append("fxcontext", options?.context || "standalone")
   return url
 }


### PR DESCRIPTION
This PR implements updating controller values through the emission event:

## Support for `fxhash_emit:params:update`
Lens now listens on this message ID and receives the updates to the controlers

## Handling of "code-driven" parameters
handling new fx(param) update mode "code-driven". In this mode controllers will be shown but `disabled`. Also a tooltip is shown on the controller indicating that the value of the controller is code-driven. When all controllers are displayed a message is displayed.

<img width="381" alt="Screenshot 2023-06-19 at 16 55 00" src="https://github.com/fxhash/fxlens/assets/1128485/0f5db952-336b-4ba0-b102-3c717732299a">

## Change iteration number
<img width="384" alt="Screenshot 2023-06-16 at 17 14 47" src="https://github.com/fxhash/fxlens/assets/1128485/f6fa6ed2-25fd-48db-a9a3-d9f13f988398">

## Change artwork "execution context"
<img width="381" alt="Screenshot 2023-06-22 at 15 48 11" src="https://github.com/fxhash/fxlens/assets/1128485/3940a342-79d8-43de-a1e0-443b761d7e15">

## Allow optional fxcontext parameter that is append to the baseUrl

e.g. http://localhost:3000/?target=http://localhost:3301&fxcontext=minting 
will set the initial fxcontext for the artwork url