### PR TITLE
add ctx option for devCli, capture controls in context

### DIFF
--- a/src/containers/Panel/PanelContext.tsx
+++ b/src/containers/Panel/PanelContext.tsx
@@ -1,47 +1,177 @@
 import styles from "./PanelContext.module.scss"
-import { useContext } from "react"
+import { useContext, useState } from "react"
 import { MainContext } from "context/MainContext"
 import { faRotate } from "@fortawesome/free-solid-svg-icons"
 import { PanelGroup } from "components/Panel/PanelGroup"
 import {
+  BaseButton,
   BaseInput,
   BaseSelect,
   IconButton,
 } from "components/FxParams/BaseInput"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { RuntimeContext, TExecutionContext } from "context/RuntimeContext"
+import { CaptureControls } from "components/FxParams/Controls"
+import { serializeParams } from "components/FxParams/utils"
 
 const contexts = ["minting", "standalone", "capture"]
+const captureParams = [
+  {
+    id: "resX",
+    name: "width",
+    type: "number",
+    options: {
+      min: 256,
+      max: 2056,
+      step: 1,
+    },
+    version: "4.0.0",
+    default: 800,
+    value: 800,
+  },
+  {
+    id: "resY",
+    name: "height",
+    type: "number",
+    options: {
+      min: 256,
+      max: 2056,
+      step: 1,
+    },
+    version: "4.0.0",
+    default: 800,
+    value: 800,
+  },
+  {
+    id: "mode",
+    name: "capture mode",
+    type: "select",
+    options: {
+      options: ["VIEWPORT", "CANVAS"],
+    },
+    version: "4.0.0",
+    default: "VIEWPORT",
+    value: "VIEWPORT",
+  },
+  {
+    id: "trigger",
+    name: "trigger by",
+    type: "select",
+    options: {
+      options: ["FN_TRIGGER", "DELAY"],
+    },
+    version: "4.0.0",
+    default: "DELAY",
+    value: "DELAY",
+  },
+  {
+    id: "delay",
+    name: "delay(s) (DELAY)",
+    type: "number",
+    options: {
+      min: 0,
+      max: 60000,
+      step: 1,
+    },
+    version: "4.0.0",
+    default: 2000,
+    value: 2000,
+  },
+  {
+    id: "selector",
+    name: "css selector (CANVAS)",
+    type: "string",
+    options: {
+      minLength: 1,
+      maxLength: 256,
+    },
+    version: "4.0.0",
+    default: "canvas",
+    value: "canvas",
+  },
+]
 
 export function PanelContext() {
   const ctx = useContext(MainContext)
   const runtime = useContext(RuntimeContext)
 
+  const [captureConfig, setCaptureConfig] = useState(
+    captureParams.reduce(
+      (acc, p) => {
+        acc[p.id] = p.value
+        return acc
+      },
+      {} as Record<string, any>
+    )
+  )
+
+  const handleCaptureConfigChange = (newData: Record<string, any>) => {
+    setCaptureConfig(newData)
+  }
   const handleChange = (context: TExecutionContext) => {
     runtime.state.update({ context })
   }
 
   return (
-    <PanelGroup
-      title="Execution context"
-      description="Simulate different contexts in which the code will be executed."
-    >
-      <div className={styles.hashControls}>
-        <BaseSelect
-          name="context"
-          className={styles.select}
-          value={runtime.state.context}
-          onChange={(evt) =>
-            handleChange(evt.target.value as TExecutionContext)
-          }
+    <>
+      <PanelGroup
+        title="Execution context"
+        description="Simulate different contexts in which the code will be executed."
+      >
+        <div className={styles.hashControls}>
+          <BaseSelect
+            name="context"
+            className={styles.select}
+            value={runtime.state.context}
+            onChange={(evt) =>
+              handleChange(evt.target.value as TExecutionContext)
+            }
+          >
+            {contexts.map((o) => (
+              <option key={o} value={o}>
+                {o}
+              </option>
+            ))}
+          </BaseSelect>
+        </div>
+      </PanelGroup>
+      {ctx.devCli && runtime.state.context === "capture" && (
+        <PanelGroup
+          title="Capture Preview"
+          description="Attempt to capture project and preview"
         >
-          {contexts.map((o) => (
-            <option key={o} value={o}>
-              {o}
-            </option>
-          ))}
-        </BaseSelect>
-      </div>
-    </PanelGroup>
+          <CaptureControls
+            captureParams={captureParams}
+            data={captureConfig}
+            onChangeData={handleCaptureConfigChange}
+          />
+          <BaseButton
+            onClick={() => {
+              if (!runtime.state.params) return
+              const bytes = serializeParams(
+                runtime.state.params,
+                runtime.definition.params!
+              )
+
+              const p = [
+                `fxhash=${runtime.state.hash}`,
+                `fxminter=${runtime.state.minter}`,
+                `fxiteration=${runtime.state.iteration}`,
+                `inputBytes=0x${bytes}`,
+              ]
+              p.push(
+                ...Object.keys(captureConfig).map((k) => {
+                  return `${k}=${captureConfig[k]}`
+                })
+              )
+              const target = `/preview?${p.join("&")}`
+              window.open(target)
+            }}
+          >
+            capture preview
+          </BaseButton>
+        </PanelGroup>
+      )}
+    </>
   )
 }

--- a/src/context/MainContext.tsx
+++ b/src/context/MainContext.tsx
@@ -23,6 +23,7 @@ export interface IMainContext {
   setFeatures: (features: any) => void
   iframe: HTMLIFrameElement | null
   setIframe: (iframe: HTMLIFrameElement) => void
+  devCli?: boolean
 }
 
 const defaultMainContext: IMainContext = {
@@ -33,15 +34,17 @@ const defaultMainContext: IMainContext = {
   setFeatures: () => {},
   iframe: null,
   setIframe: () => {},
+  devCli: false,
 }
 
 export const MainContext = createContext(defaultMainContext)
 
 type Props = PropsWithChildren<any>
 export function MainProvider({ children }: Props) {
-  const baseUrl = decodeUrl(
-    new URLSearchParams(window.location.search).get("target") || ""
-  )
+  const params = new URLSearchParams(window.location.search)
+  const baseUrl = decodeUrl(params.get("target") || "")
+  // running through fxhash cli dev cmd
+  const devCli = params.get("devCli") ? true : false
   const initialContext = new URLSearchParams(window.location.search).get(
     "fxcontext"
   ) as TExecutionContext
@@ -63,6 +66,7 @@ export function MainProvider({ children }: Props) {
     setFeatures,
     iframe,
     setIframe,
+    devCli,
   }
 
   return <MainContext.Provider value={context}>{children}</MainContext.Provider>


### PR DESCRIPTION
when paired with fxhash-cli's `dev` mode PR for preview route for (fx)lens

https://github.com/fxhash/fxhash-package/pull/46

![image](https://github.com/fxhash/fxlens/assets/1828125/73a89965-04f0-4830-85f2-4914c7d30ab3)
![image](https://github.com/fxhash/fxlens/assets/1828125/2ea18ca9-5c01-4050-a589-7e1b0829a3a9)
